### PR TITLE
Make lint faster

### DIFF
--- a/CLI/lint.sh
+++ b/CLI/lint.sh
@@ -4,6 +4,6 @@ set -e
 
 pushd $(git rev-parse --show-toplevel)
 
-swift run --only-use-versions-from-resolved-file --package-path CLI --scratch-path .build -c release swiftformat --swiftversion 6.0 .
+swift run --only-use-versions-from-resolved-file --package-path CLI --scratch-path .build swiftformat --swiftversion 6.0 .
 
 popd


### PR DESCRIPTION
We don't need to build the linter in release mode. This repo is small, and the time to build the linter outweighs the speed benefit to listing post-build.